### PR TITLE
feat: Add chained and unchained init functions to NativeMetaTransaction and NonceVerifiable

### DIFF
--- a/contracts/meta-transactions/NativeMetaTransaction.sol
+++ b/contracts/meta-transactions/NativeMetaTransaction.sol
@@ -20,6 +20,10 @@ abstract contract NativeMetaTransaction is EIP712Upgradeable {
 
     event MetaTransactionExecuted(address _userAddress, address _relayerAddress, bytes _functionData);
 
+    function __NativeMetaTransaction_init(string memory _name, string memory _version) internal onlyInitializing {
+        __EIP712_init(_name, _version);
+    }
+
     /// @notice Execute a transaction from the contract appending _userAddress to the call data.
     /// @dev The appended address can then be extracted from the called context with _getMsgSender instead of using msg.sender.
     /// The caller of `executeMetaTransaction` will pay for gas fees so _userAddress can experience "gasless" transactions.

--- a/contracts/meta-transactions/NativeMetaTransaction.sol
+++ b/contracts/meta-transactions/NativeMetaTransaction.sol
@@ -20,7 +20,7 @@ abstract contract NativeMetaTransaction is EIP712Upgradeable {
 
     event MetaTransactionExecuted(address _userAddress, address _relayerAddress, bytes _functionData);
 
-    function __NativeMetaTransaction_init(string memory _name, string memory _version) internal {
+    function __NativeMetaTransaction_init(string memory _name, string memory _version) internal onlyInitializing {
         __EIP712_init(_name, _version);
     }
 

--- a/contracts/meta-transactions/NativeMetaTransaction.sol
+++ b/contracts/meta-transactions/NativeMetaTransaction.sol
@@ -20,7 +20,7 @@ abstract contract NativeMetaTransaction is EIP712Upgradeable {
 
     event MetaTransactionExecuted(address _userAddress, address _relayerAddress, bytes _functionData);
 
-    function __NativeMetaTransaction_init(string memory _name, string memory _version) internal onlyInitializing {
+    function __NativeMetaTransaction_init(string memory _name, string memory _version) internal {
         __EIP712_init(_name, _version);
     }
 

--- a/contracts/mocks/DummyNativeMetaTransactionImplementator.sol
+++ b/contracts/mocks/DummyNativeMetaTransactionImplementator.sol
@@ -12,6 +12,10 @@ contract DummyNativeMetaTransactionImplementator is NativeMetaTransaction {
         __NativeMetaTransaction_init("DummyNativeMetaTransactionImplementator", "1");
     }
 
+    function test__NativeMetaTransaction_init() external {
+        __NativeMetaTransaction_init("DummyNativeMetaTransactionImplementator", "1");
+    }
+
     function increaseCounter(uint256 _amount) external {
         increaseCounterCaller = _getMsgSender();
         counter += _amount;

--- a/contracts/mocks/DummyNativeMetaTransactionImplementator.sol
+++ b/contracts/mocks/DummyNativeMetaTransactionImplementator.sol
@@ -16,6 +16,10 @@ contract DummyNativeMetaTransactionImplementator is NativeMetaTransaction {
         __NativeMetaTransaction_init("DummyNativeMetaTransactionImplementator", "1");
     }
 
+    function getNameAndVersionHash() external view returns (bytes32, bytes32) {
+        return (_EIP712NameHash(), _EIP712VersionHash());
+    }
+
     function increaseCounter(uint256 _amount) external {
         increaseCounterCaller = _getMsgSender();
         counter += _amount;

--- a/contracts/mocks/DummyNativeMetaTransactionImplementator.sol
+++ b/contracts/mocks/DummyNativeMetaTransactionImplementator.sol
@@ -9,7 +9,7 @@ contract DummyNativeMetaTransactionImplementator is NativeMetaTransaction {
     address public increaseCounterCaller;
 
     function initialize() external initializer {
-        __EIP712_init("DummyNativeMetaTransactionImplementator", "1");
+        __NativeMetaTransaction_init("DummyNativeMetaTransactionImplementator", "1");
     }
 
     function increaseCounter(uint256 _amount) external {

--- a/contracts/mocks/DummyNonceVerifiableImplementator.sol
+++ b/contracts/mocks/DummyNonceVerifiableImplementator.sol
@@ -10,6 +10,10 @@ contract DummyNonceVerifiableImplementator is NonceVerifiable {
         _transferOwnership(_owner);
     }
 
+    function test__NonceVerifiable_init() external {
+        __NonceVerifiable_init();
+    }
+
     function verifyContractNonce(uint256 _nonce) external view {
         _verifyContractNonce(_nonce);
     }

--- a/contracts/mocks/DummyNonceVerifiableImplementator.sol
+++ b/contracts/mocks/DummyNonceVerifiableImplementator.sol
@@ -5,7 +5,8 @@ pragma solidity ^0.8.7;
 import "../signatures/NonceVerifiable.sol";
 
 contract DummyNonceVerifiableImplementator is NonceVerifiable {
-    constructor(address _owner) {
+    function initialize(address _owner) external initializer {
+        __NonceVerifiable_init();
         _transferOwnership(_owner);
     }
 

--- a/contracts/mocks/DummyNonceVerifiableImplementator.sol
+++ b/contracts/mocks/DummyNonceVerifiableImplementator.sol
@@ -5,9 +5,8 @@ pragma solidity ^0.8.7;
 import "../signatures/NonceVerifiable.sol";
 
 contract DummyNonceVerifiableImplementator is NonceVerifiable {
-    function initialize(address _owner) external initializer {
+    function initialize() external initializer {
         __NonceVerifiable_init();
-        _transferOwnership(_owner);
     }
 
     function test__NonceVerifiable_init() external {

--- a/contracts/signatures/NonceVerifiable.sol
+++ b/contracts/signatures/NonceVerifiable.sol
@@ -23,7 +23,7 @@ abstract contract NonceVerifiable is OwnableUpgradeable {
     event SignerNonceUpdated(uint256 _from, uint256 _to, address _signer, address _sender);
     event AssetNonceUpdated(uint256 _from, uint256 _to, address _contractAddress, uint256 _tokenId, address _signer, address _sender);
 
-    function __NonceVerifiable_init() internal {
+    function __NonceVerifiable_init() internal onlyInitializing {
         __Ownable_init();
     }
 

--- a/contracts/signatures/NonceVerifiable.sol
+++ b/contracts/signatures/NonceVerifiable.sol
@@ -23,7 +23,7 @@ abstract contract NonceVerifiable is OwnableUpgradeable {
     event SignerNonceUpdated(uint256 _from, uint256 _to, address _signer, address _sender);
     event AssetNonceUpdated(uint256 _from, uint256 _to, address _contractAddress, uint256 _tokenId, address _signer, address _sender);
 
-    function __NonceVerifiable_init() internal onlyInitializing {
+    function __NonceVerifiable_init() internal {
         __Ownable_init();
     }
 

--- a/contracts/signatures/NonceVerifiable.sol
+++ b/contracts/signatures/NonceVerifiable.sol
@@ -23,6 +23,10 @@ abstract contract NonceVerifiable is OwnableUpgradeable {
     event SignerNonceUpdated(uint256 _from, uint256 _to, address _signer, address _sender);
     event AssetNonceUpdated(uint256 _from, uint256 _to, address _contractAddress, uint256 _tokenId, address _signer, address _sender);
 
+    function __NonceVerifiable_init() internal onlyInitializing {
+        __Ownable_init();
+    }
+
     /// @notice As the owner of the contract, increase the contract nonce by 1.
     function bumpContractNonce() external onlyOwner {
         _bumpContractNonce();

--- a/test/NativeMetaTransaction.spec.ts
+++ b/test/NativeMetaTransaction.spec.ts
@@ -30,6 +30,25 @@ describe('NativeMetaTransaction', () => {
     relayer = await RelayerFactory.connect(deployer).deploy(nmtImplementator.address)
   })
 
+  describe('initialize', () => {
+    it('should set eip712 name and version hash after initialize', async () => {
+      NMTImplementatorFactory = await ethers.getContractFactory('DummyNativeMetaTransactionImplementator')
+      nmtImplementator = await NMTImplementatorFactory.connect(deployer).deploy()
+
+      let nameAndVersionHashes = await nmtImplementator.getNameAndVersionHash()
+
+      expect(nameAndVersionHashes[0]).to.be.equal('0x0000000000000000000000000000000000000000000000000000000000000000')
+      expect(nameAndVersionHashes[1]).to.be.equal('0x0000000000000000000000000000000000000000000000000000000000000000')
+
+      await nmtImplementator.connect(deployer).initialize()
+
+      nameAndVersionHashes = await nmtImplementator.getNameAndVersionHash()
+
+      expect(nameAndVersionHashes[0]).to.be.equal('0x6baad1a72bd9870da55684691faafc1a398ac29693b22f98f50df610295a1a47')
+      expect(nameAndVersionHashes[1]).to.be.equal('0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6')
+    })
+  })
+
   describe('__NativeMetaTransaction_init', () => {
     it('should revert when called after initialization', async () => {
       await expect(nmtImplementator.test__NativeMetaTransaction_init()).to.be.revertedWith('Initializable: contract is not initializing')

--- a/test/NativeMetaTransaction.spec.ts
+++ b/test/NativeMetaTransaction.spec.ts
@@ -30,6 +30,12 @@ describe('NativeMetaTransaction', () => {
     relayer = await RelayerFactory.connect(deployer).deploy(nmtImplementator.address)
   })
 
+  describe('__NativeMetaTransaction_init', () => {
+    it('should revert when called after initialization', async () => {
+      await expect(nmtImplementator.test__NativeMetaTransaction_init()).to.be.revertedWith('Initializable: contract is not initializing')
+    })
+  })
+
   describe('_getMsgSender', () => {
     it('should extract the provided _userAddress instead of the msg.sender', async () => {
       const abi = ['function increaseCounter(uint256 _amount)']

--- a/test/NativeMetaTransaction.spec.ts
+++ b/test/NativeMetaTransaction.spec.ts
@@ -47,6 +47,10 @@ describe('NativeMetaTransaction', () => {
       expect(nameAndVersionHashes[0]).to.be.equal('0x6baad1a72bd9870da55684691faafc1a398ac29693b22f98f50df610295a1a47')
       expect(nameAndVersionHashes[1]).to.be.equal('0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6')
     })
+
+    it('should revert when initialized twice', async () => {
+      await expect(nmtImplementator.initialize()).to.be.revertedWith('Initializable: contract is already initialized')
+    })
   })
 
   describe('__NativeMetaTransaction_init', () => {

--- a/test/NonceVerifiable.spec.ts
+++ b/test/NonceVerifiable.spec.ts
@@ -18,7 +18,21 @@ describe('NonceVerifiable', () => {
     contractFactory = await ethers.getContractFactory('DummyNonceVerifiableImplementator')
     contract = await contractFactory.deploy()
 
-    await contract.connect(deployer).initialize(owner.address)
+    await contract.connect(deployer).initialize()
+    await contract.connect(deployer).transferOwnership(owner.address)
+  })
+
+  describe('initialize', () => {
+    it('should set the owner as the caller after initializing', async () => {
+      contractFactory = await ethers.getContractFactory('DummyNonceVerifiableImplementator')
+      contract = await contractFactory.deploy()
+
+      expect(await contract.owner()).to.be.equal('0x0000000000000000000000000000000000000000')
+
+      await contract.initialize()
+
+      expect(await contract.owner()).to.be.equal(deployer.address)
+    })
   })
 
   describe('__NonceVerifiable_init', () => {

--- a/test/NonceVerifiable.spec.ts
+++ b/test/NonceVerifiable.spec.ts
@@ -21,17 +21,11 @@ describe('NonceVerifiable', () => {
     await contract.connect(deployer).initialize(owner.address)
   })
 
-  describe('initialize', () => {
+  describe('__NonceVerifiable_init', () => {
     it('should set the owner', async () => {
       expect(await contract.owner()).to.be.equal(owner.address)
     })
 
-    it('should revert when initialized twice', async () => {
-      await expect(contract.connect(deployer).initialize(owner.address)).to.be.revertedWith('Initializable: contract is already initialized')
-    })
-  })
-
-  describe('__NonceVerifiable_init', () => {
     it('should revert when called after initialization', async () => {
       await expect(contract.connect(deployer).test__NonceVerifiable_init()).to.be.revertedWith('Initializable: contract is not initializing')
     })

--- a/test/NonceVerifiable.spec.ts
+++ b/test/NonceVerifiable.spec.ts
@@ -21,6 +21,22 @@ describe('NonceVerifiable', () => {
     await contract.connect(deployer).initialize(owner.address)
   })
 
+  describe('initialize', () => {
+    it('should set the owner', async () => {
+      expect(await contract.owner()).to.be.equal(owner.address)
+    })
+
+    it('should revert when initialized twice', async () => {
+      await expect(contract.connect(deployer).initialize(owner.address)).to.be.revertedWith('Initializable: contract is already initialized')
+    })
+  })
+
+  describe('__NonceVerifiable_init', () => {
+    it('should revert when called after initialization', async () => {
+      await expect(contract.connect(deployer).test__NonceVerifiable_init()).to.be.revertedWith('Initializable: contract is not initializing')
+    })
+  })
+
   describe('bumpContractNonce', () => {
     it('should increase the contract nonce by 1', async () => {
       expect(await contract.contractNonce()).to.be.equal(0)

--- a/test/NonceVerifiable.spec.ts
+++ b/test/NonceVerifiable.spec.ts
@@ -16,7 +16,9 @@ describe('NonceVerifiable', () => {
     ;[deployer, owner, signer, extra] = await ethers.getSigners()
 
     contractFactory = await ethers.getContractFactory('DummyNonceVerifiableImplementator')
-    contract = await contractFactory.deploy(owner.address)
+    contract = await contractFactory.deploy()
+
+    await contract.connect(deployer).initialize(owner.address)
   })
 
   describe('bumpContractNonce', () => {

--- a/test/NonceVerifiable.spec.ts
+++ b/test/NonceVerifiable.spec.ts
@@ -33,6 +33,10 @@ describe('NonceVerifiable', () => {
 
       expect(await contract.owner()).to.be.equal(deployer.address)
     })
+
+    it('should revert when initialized twice', async () => {
+      await expect(contract.initialize()).to.be.revertedWith('Initializable: contract is already initialized')
+    })
   })
 
   describe('__NonceVerifiable_init', () => {


### PR DESCRIPTION
This way, contracts that inherit them can call their respective __NativeMetaTransaction_init and __NonceVerifiable_init instead of called their parents init functions directly.

https://docs.openzeppelin.com/contracts/4.x/upgradeable#multiple-inheritance