### PR TITLE
feat: Add unchained functions

### DIFF
--- a/contracts/meta-transactions/NativeMetaTransaction.sol
+++ b/contracts/meta-transactions/NativeMetaTransaction.sol
@@ -24,6 +24,8 @@ abstract contract NativeMetaTransaction is EIP712Upgradeable {
         __EIP712_init(_name, _version);
     }
 
+    function __NativeMetaTransaction_init_unchained() internal onlyInitializing {}
+
     /// @notice Execute a transaction from the contract appending _userAddress to the call data.
     /// @dev The appended address can then be extracted from the called context with _getMsgSender instead of using msg.sender.
     /// The caller of `executeMetaTransaction` will pay for gas fees so _userAddress can experience "gasless" transactions.

--- a/contracts/signatures/NonceVerifiable.sol
+++ b/contracts/signatures/NonceVerifiable.sol
@@ -27,6 +27,8 @@ abstract contract NonceVerifiable is OwnableUpgradeable {
         __Ownable_init();
     }
 
+    function __NonceVerifiable_init_unchained() internal onlyInitializing {}
+
     /// @notice As the owner of the contract, increase the contract nonce by 1.
     function bumpContractNonce() external onlyOwner {
         _bumpContractNonce();


### PR DESCRIPTION
Added stub unchained functions so it is similar to how OZ implements it.

For example:

```solidity
abstract contract ContextUpgradeable is Initializable {
    function __Context_init() internal onlyInitializing {
    }

    function __Context_init_unchained() internal onlyInitializing {
    }
```

As you can see, ContextUpgradable has both init functions even if they do nothing.