### PR TITLE
feat: Update oz package to 4.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.4",
         "@nomiclabs/hardhat-waffle": "^2.0.2",
-        "@openzeppelin/contracts-upgradeable": "^4.5.0",
+        "@openzeppelin/contracts-upgradeable": "^4.7.3",
         "@typechain/ethers-v5": "^9.0.0",
         "@typechain/hardhat": "^4.0.0",
         "@types/chai": "^4.3.0",
@@ -1448,9 +1448,9 @@
       }
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.0.tgz",
-      "integrity": "sha512-5540xxycH2aDFI3e+5Mqd0GDeozkSKSEaNWoM65l90OYxZxOs9YQMqa+b4fR+363BXXSXoC1DTXut2TuqViwPA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz",
+      "integrity": "sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==",
       "dev": true
     },
     "node_modules/@resolver-engine/core": {
@@ -22154,9 +22154,9 @@
       }
     },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.0.tgz",
-      "integrity": "sha512-5540xxycH2aDFI3e+5Mqd0GDeozkSKSEaNWoM65l90OYxZxOs9YQMqa+b4fR+363BXXSXoC1DTXut2TuqViwPA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz",
+      "integrity": "sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==",
       "dev": true
     },
     "@resolver-engine/core": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.4",
     "@nomiclabs/hardhat-waffle": "^2.0.2",
-    "@openzeppelin/contracts-upgradeable": "^4.5.0",
+    "@openzeppelin/contracts-upgradeable": "^4.7.3",
     "@typechain/ethers-v5": "^9.0.0",
     "@typechain/hardhat": "^4.0.0",
     "@types/chai": "^4.3.0",
@@ -35,6 +35,6 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@openzeppelin/contracts-upgradeable": "^4.5.0"
+    "@openzeppelin/contracts-upgradeable": "^4.7.3"
   }
 }


### PR DESCRIPTION
Closes #22 

Despite the rentals contract not being affected by https://github.com/decentraland/common-contracts/security/dependabot/29. It is better to have this potential vulnerability removed from project importing common-contracts